### PR TITLE
Docs update: prerequisite & runw set-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ sudo crictl pull docker.io/beststeve/wasm-pause
 
 # Install runw into cri-o
 sudo cp -v runw /usr/lib/cri-o-runc/sbin/runw
+sudo chmod +x /usr/lib/cri-o-runc/sbin/runw
 sudo sed -i -e 's@default_runtime = "runc"@default_runtime = "runw"@' /etc/crio/crio.conf
 sudo sed -i -e 's@pause_image = "k8s.gcr.io/pause:3.2"@pause_image = "docker.io/beststeve/wasm-pause"@' /etc/crio/crio.conf
 sudo sed -i -e 's@pause_command = "/pause"@pause_command = "pause.wasm"@' /etc/crio/crio.conf

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Please install the following tools for container management.
 
 * [cri-o](https://cri-o.io/)
 * [crictl](https://github.com/kubernetes-sigs/cri-tools)
+* [containernetworking-plugins](https://github.com/containernetworking/plugins)
 * Optional [buildah](https://github.com/containers/buildah) or [docker](https://github.com/docker/cli) for building container image
 
 ## Use pre-built runw


### PR DESCRIPTION
1. Add containernetworking-plugins to prerequisite;
2. Add `chmod +x runw` to **Install runw into cri-o** section (downloading `runw` release from GitHub will causing it to lose executable mode).